### PR TITLE
Basiq-37: Merchant logos mixed up

### DIFF
--- a/components/ListItem.js
+++ b/components/ListItem.js
@@ -1,24 +1,23 @@
 import { formatCurrency } from '../utils/formatCurrency';
 
-export function ListItem({ item, imagePrefix, randomDivider }) {
+export function ListItem({ item, imagePrefix }) {
   return (
-    <div className="p-2 mb-2 sm:bg-[#F5F7F8] bg-list-item-color sm:p-4 rounded-[20px]">
+    <div className="p-2 mb-2 sm:bg-[#F5F7F8] bg-list-item-color sm:p-4 rounded-[20px] sm:overflow-hidden">
       <div className="flex justify-between">
         <div className="flex">
-          <div>
-            {/* Shuffling random icons */}
-            <img className="w-9 h-9" src={`/${imagePrefix}-${parseInt(Math.random() * 100 % randomDivider)}.svg`} alt={imagePrefix} />
+          <div className="w-9 h-9 self-center">
+            <img src={`/${imagePrefix}-${item?.index}.svg`} alt={imagePrefix} />
           </div>
-          <div className="ml-2 text-sm2 sm:text-sm3">
+          <div className="ml-2 text-sm2 sm:text-sm3 truncate">
             <div className="font-medium">
               {item.description}
             </div>
-            <div className="text-xs font-normal sm:text-sm2">
+            <div className="text-xs font-normal sm:text-sm2 truncate">
               {item.dateDescription}
             </div>
           </div>
         </div>
-        <div className="self-center font-semibold text-blue">
+        <div className="self-center font-semibold text-blue truncate">
           {formatCurrency(item.amount)}
         </div>
       </div>

--- a/components/PersonalFinance/Chart/HomeCharts.js
+++ b/components/PersonalFinance/Chart/HomeCharts.js
@@ -15,13 +15,13 @@ const items = [
 
 const upcomingPayments = [
   {
-    description: 'Disney+', dateDescription: '5th of every month', amount: '-20.00',index:'0'
+    description: 'Disney+', dateDescription: '5th of every month', amount: '-20.00', index: '0'
   },
   {
-    description: 'Spotify', dateDescription: '18th of every month', amount: '-11.00',index:'1'
+    description: 'Spotify', dateDescription: '18th of every month', amount: '-11.00', index: '1'
   },
   {
-    description: 'Amazon', dateDescription: '10th of May, every year', amount: '-20.00',index:'2'
+    description: 'Amazon', dateDescription: '10th of May, every year', amount: '-20.00', index: '2'
   },
 ]
 

--- a/components/PersonalFinance/Chart/HomeCharts.js
+++ b/components/PersonalFinance/Chart/HomeCharts.js
@@ -15,13 +15,13 @@ const items = [
 
 const upcomingPayments = [
   {
-    description: 'Disney+', dateDescription: '5th of every month', amount: '-20.00'
+    description: 'Disney+', dateDescription: '5th of every month', amount: '-20.00',index:'0'
   },
   {
-    description: 'Spotify', dateDescription: '18th of every month', amount: '-11.00'
+    description: 'Spotify', dateDescription: '18th of every month', amount: '-11.00',index:'1'
   },
   {
-    description: 'Amazon', dateDescription: '10th of May, every year', amount: '-20.00'
+    description: 'Amazon', dateDescription: '10th of May, every year', amount: '-20.00',index:'2'
   },
 ]
 


### PR DESCRIPTION
In case the page shrinks, the texts coming one after the other are prevented so that they appear in a single type.